### PR TITLE
Migrate action to macos-latest

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-10.14, windows-2016, ubuntu-18.04]
+        os: [macOS-latest, windows-2016, ubuntu-18.04]
         node-version: [10.x, 12.x]
 
     steps:


### PR DESCRIPTION
Message from GitHub says:

> Any jobs in your workflows that run on the `macos-10.14` virtual environment must migrate to `macos-latest`. Going forward, we will only support the `macos-latest` environment which will run Catalina (10.15). Once the migration to Catalina is complete, jobs using `macos-10.14` will no longer run.